### PR TITLE
Allow MinGW build to work out-of-box on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 CXX = g++
 CXXFLAGS = -Wall -Wextra -Wpedantic -Wshadow
+ifeq ($(OS),Windows_NT)
+	CXXFLAGS += -static
+endif
 OUTPUT = range_randomizer
 
 all: main

--- a/romprocessor.cpp
+++ b/romprocessor.cpp
@@ -3,8 +3,8 @@
 using namespace std;
 
 RomProcessor::RomProcessor(const char *in_path, const char *out_path) {
-    rom_file.open(in_path);
-    out_file.open(out_path, fstream::in | fstream::out | fstream::trunc);
+    rom_file.open(in_path, fstream::in | fstream::binary);
+    out_file.open(out_path, fstream::in | fstream::out | fstream::trunc | fstream::binary);
 
     out_file << rom_file.rdbuf(); out_file.flush(); // copy over file
 


### PR DESCRIPTION
So I may have decided to try and work on some of this. 

This PR allows the build to work out-of-box on Windows

- Removes the end-user dependency on a MinGW environment by building with -static if building on Windows (Fixes #2)
- Fixes an error caused by mistakenly opening the input and output ROM files in text mode (causing "line endings" in the rom to be replaced on windows [see [https://en.cppreference.com/w/cpp/io/c/FILE#Binary_and_text_modes](https://en.cppreference.com/w/cpp/io/c/FILE#Binary_and_text_modes)]).
  - Open input and output ROMs in binary mode
  - See attached screenshot for error caused by not doing this (with a known good input ROM)

![image](https://github.com/ronitsinha/almia-randomizer/assets/18287167/741d3a7f-3a13-4dd0-a590-294bab06e6de)
